### PR TITLE
[FEAT] 로그아웃 로직 구현

### DIFF
--- a/src/main/java/heroes/domain/auth/api/AuthController.java
+++ b/src/main/java/heroes/domain/auth/api/AuthController.java
@@ -7,6 +7,7 @@ import heroes.domain.auth.dto.response.TokenPairResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +30,12 @@ public class AuthController {
     @PostMapping("/refresh")
     public TokenPairResponse refreshToken(@RequestBody TokenRefreshRequest request) {
         return authService.tokenRefresh(request);
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout() {
+        authService.memberLogout();
+        return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
## 💡 Issue
- #27 

## 📌 Work Description
### 로그아웃 로직 구현
- 엑세스토큰을 가지고 접근하여 로그아웃을 진행하는 경우 엑세스토큰을 가지고 요청 사용자 정보를 찾아 저장된 리프레시 토큰을 제거합니다. 

## 📝 Reference
- X

## 📚 Etc
- X