### PR TITLE
[FEAT] 기업 유저 회원가입 로직 구현(#34)

### DIFF
--- a/src/main/java/heroes/domain/bookmark/api/CompanyBookmarkController.java
+++ b/src/main/java/heroes/domain/bookmark/api/CompanyBookmarkController.java
@@ -6,10 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "기업 API", description = "기업 사용자 관련 API입니다.")
 @RestController
@@ -23,5 +20,12 @@ public class CompanyBookmarkController {
     public ResponseEntity<Void> createBookmark(@PathVariable Long companyId) {
         bookmarkService.createCompanyBookmark(companyId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "기업 북마크 해제", description = "지정한 기업에 적용했던 북마크를 해제합니다.")
+    @DeleteMapping("/{companyId}")
+    public ResponseEntity<Void> deleteBookmark(@PathVariable Long companyId) {
+        bookmarkService.deleteCompanyBookmark(companyId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/heroes/domain/bookmark/application/CompanyBookmarkService.java
+++ b/src/main/java/heroes/domain/bookmark/application/CompanyBookmarkService.java
@@ -23,12 +23,27 @@ public class CompanyBookmarkService {
     public void createCompanyBookmark(Long companyId) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        Company company =
-                companyRepository
-                        .findById(companyId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+        Company company = findCompanyById(companyId);
         validateBookmarkExist(currentMember, company);
         bookmarkRepository.save(CompanyBookmark.create(company, currentMember));
+    }
+
+    public void deleteCompanyBookmark(Long companyId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        Company company = findCompanyById(companyId);
+        CompanyBookmark bookmark =
+                bookmarkRepository
+                        .findByCompanyAndMember(company, currentMember)
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.COMPANY_BOOKMARK_NOT_FOUND));
+        bookmarkRepository.delete(bookmark.remove());
+    }
+
+    private Company findCompanyById(Long companyId) {
+        return companyRepository
+                .findById(companyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
     }
 
     private void validateBookmarkExist(Member currentMember, Company company) {

--- a/src/main/java/heroes/domain/bookmark/dao/CompanyBookmarkRepository.java
+++ b/src/main/java/heroes/domain/bookmark/dao/CompanyBookmarkRepository.java
@@ -3,10 +3,13 @@ package heroes.domain.bookmark.dao;
 import heroes.domain.bookmark.domain.CompanyBookmark;
 import heroes.domain.company.domain.Company;
 import heroes.domain.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CompanyBookmarkRepository extends JpaRepository<CompanyBookmark, Long> {
     boolean existsByCompanyAndMember(Company company, Member member);
+
+    Optional<CompanyBookmark> findByCompanyAndMember(Company company, Member member);
 }

--- a/src/main/java/heroes/domain/bookmark/domain/CompanyBookmark.java
+++ b/src/main/java/heroes/domain/bookmark/domain/CompanyBookmark.java
@@ -38,4 +38,10 @@ public class CompanyBookmark {
         company.getBookmarks().add(bookmark);
         return bookmark;
     }
+
+    public CompanyBookmark remove() {
+        member.getBookmarks().remove(this);
+        company.getBookmarks().remove(this);
+        return this;
+    }
 }

--- a/src/main/java/heroes/domain/company/api/CompanyController.java
+++ b/src/main/java/heroes/domain/company/api/CompanyController.java
@@ -1,0 +1,28 @@
+package heroes.domain.company.api;
+
+import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
+import heroes.domain.company.application.CompanyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "기업 API", description = "기업 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/companies")
+public class CompanyController {
+
+    private final CompanyService companyService;
+
+    @Operation(summary = "기업 이미지 url 발급", description = "기업 이미지 업로드를 위한 presigned url을 발급합니다.")
+    @GetMapping("/generate-url")
+    public List<PresignedUrlIssueResponse> getImageUploadUrl(@RequestParam("imageType") String imageType, @RequestParam("size")int size) {
+        return companyService.getImageUploadUrl(imageType, size);
+    }
+}

--- a/src/main/java/heroes/domain/company/api/CompanyController.java
+++ b/src/main/java/heroes/domain/company/api/CompanyController.java
@@ -3,7 +3,8 @@ package heroes.domain.company.api;
 import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
 import heroes.domain.company.application.CompanyService;
 import heroes.domain.company.dto.request.CompanyCreateRequest;
-import heroes.domain.company.dto.response.CompanyCreateResponse;
+import heroes.domain.company.dto.request.CompanyUpdateRequest;
+import heroes.domain.company.dto.response.CompanyChangeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,13 @@ public class CompanyController {
 
     @Operation(summary = "기업 신규 정보 기입", description = "기업 정보 신규로 생성합니다.")
     @PatchMapping()
-    public CompanyCreateResponse updateCompany(@RequestBody CompanyCreateRequest request) {
+    public CompanyChangeResponse createCompany(@RequestBody CompanyCreateRequest request) {
+        return companyService.createCompany(request);
+    }
+
+    @Operation(summary = "기업 정보 수정", description = "기업 정보 신규로 생성합니다.")
+    @PatchMapping("/update")
+    public CompanyChangeResponse updateCompany(@RequestBody CompanyUpdateRequest request) {
         return companyService.updateCompany(request);
     }
 }

--- a/src/main/java/heroes/domain/company/api/CompanyController.java
+++ b/src/main/java/heroes/domain/company/api/CompanyController.java
@@ -2,13 +2,13 @@ package heroes.domain.company.api;
 
 import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
 import heroes.domain.company.application.CompanyService;
+import heroes.domain.company.dto.request.CompanyCreateRequest;
+import heroes.domain.company.dto.response.CompanyCreateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,5 +24,12 @@ public class CompanyController {
     @GetMapping("/generate-url")
     public List<PresignedUrlIssueResponse> getImageUploadUrl(@RequestParam("imageType") String imageType, @RequestParam("size")int size) {
         return companyService.getImageUploadUrl(imageType, size);
+    }
+
+    @Operation(summary = "기업 신규 정보 기입", description = "기업 이미지 업로드를 위한 presigned url을 발급합니다.")
+    @PatchMapping("")
+    public ResponseEntity<CompanyCreateResponse> updateCompany(@RequestBody CompanyCreateRequest request) {
+        CompanyCreateResponse response = companyService.updateCompany(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/heroes/domain/company/api/CompanyController.java
+++ b/src/main/java/heroes/domain/company/api/CompanyController.java
@@ -7,7 +7,6 @@ import heroes.domain.company.dto.response.CompanyCreateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,10 +25,9 @@ public class CompanyController {
         return companyService.getImageUploadUrl(imageType, size);
     }
 
-    @Operation(summary = "기업 신규 정보 기입", description = "기업 이미지 업로드를 위한 presigned url을 발급합니다.")
-    @PatchMapping("")
-    public ResponseEntity<CompanyCreateResponse> updateCompany(@RequestBody CompanyCreateRequest request) {
-        CompanyCreateResponse response = companyService.updateCompany(request);
-        return ResponseEntity.ok(response);
+    @Operation(summary = "기업 신규 정보 기입", description = "기업 정보 신규로 생성합니다.")
+    @PatchMapping()
+    public CompanyCreateResponse updateCompany(@RequestBody CompanyCreateRequest request) {
+        return companyService.updateCompany(request);
     }
 }

--- a/src/main/java/heroes/domain/company/application/CompanyService.java
+++ b/src/main/java/heroes/domain/company/application/CompanyService.java
@@ -2,11 +2,13 @@ package heroes.domain.company.application;
 
 import heroes.domain.common.presignedurl.application.PresignedUrlService;
 import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
-import heroes.domain.company.dao.CompanyRepository;
 import heroes.domain.company.domain.Company;
 import heroes.domain.company.dto.request.CompanyCreateRequest;
 import heroes.domain.company.dto.request.ImageType;
 import heroes.domain.company.dto.response.CompanyCreateResponse;
+import heroes.domain.companyhour.domain.CompanyHour;
+import heroes.domain.companyhour.domain.DayOfWeek;
+import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
 import heroes.global.common.validations.EnumValue;
 import heroes.global.error.exception.CustomException;
 import heroes.global.error.exception.ErrorCode;
@@ -15,10 +17,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static heroes.global.common.constants.MessageConstants.INVALID_IMAGE_TYPE_MESSAGE;
 import static heroes.global.common.constants.PresignedUrlConstants.*;
 @Transactional
 @Service
@@ -28,7 +32,7 @@ public class CompanyService {
     private final CompanyUtil companyUtil;
 
     public List<PresignedUrlIssueResponse> getImageUploadUrl(
-            @EnumValue(enumClass = ImageType.class, message = "이미지 유형이 잘못되었습니다.", ignoreCase = true)
+            @EnumValue(enumClass = ImageType.class, message = INVALID_IMAGE_TYPE_MESSAGE, ignoreCase = true)
             String imageType,
             int size) {
         Company currentCompany = companyUtil.getCurrentCompany();

--- a/src/main/java/heroes/domain/company/application/CompanyService.java
+++ b/src/main/java/heroes/domain/company/application/CompanyService.java
@@ -1,0 +1,44 @@
+package heroes.domain.company.application;
+
+import heroes.domain.common.presignedurl.application.PresignedUrlService;
+import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
+import heroes.domain.company.dao.CompanyRepository;
+import heroes.domain.company.domain.Company;
+import heroes.domain.company.dto.request.ImageType;
+import heroes.global.common.validations.EnumValue;
+import heroes.global.util.CompanyUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static heroes.global.common.constants.PresignedUrlConstants.*;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyService {
+    private final PresignedUrlService presignedUrlService;
+    private final CompanyRepository companyRepository;
+    private final CompanyUtil companyUtil;
+
+    public List<PresignedUrlIssueResponse> getImageUploadUrl(
+            @EnumValue(enumClass = ImageType.class, message = "결제 유형이 잘못되었습니다.", ignoreCase = true)
+            String imageType,
+            int size) {
+        Company currentCompany = companyUtil.getCurrentCompany();
+
+        return switch (imageType) {
+            case "MAIN" -> List.of(presignedUrlService.generatePresignedUrl(
+                    COMPANY_DIRECTORY + COMPANY_MAIN_DIRECTORY + currentCompany.getId().toString()));
+            case "SUB" -> IntStream.range(0, size)
+                    .mapToObj(i -> presignedUrlService.generatePresignedUrl(
+                            COMPANY_DIRECTORY + COMPANY_SUB_DIRECTORY + currentCompany.getId().toString() + SLASH + i))
+                    .collect(Collectors.toList());
+            default -> throw new IllegalArgumentException("Invalid imageType: " + imageType);
+        };
+    }
+
+
+}

--- a/src/main/java/heroes/domain/company/application/CompanyService.java
+++ b/src/main/java/heroes/domain/company/application/CompanyService.java
@@ -4,27 +4,31 @@ import heroes.domain.common.presignedurl.application.PresignedUrlService;
 import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
 import heroes.domain.company.dao.CompanyRepository;
 import heroes.domain.company.domain.Company;
+import heroes.domain.company.dto.request.CompanyCreateRequest;
 import heroes.domain.company.dto.request.ImageType;
+import heroes.domain.company.dto.response.CompanyCreateResponse;
 import heroes.global.common.validations.EnumValue;
+import heroes.global.error.exception.CustomException;
+import heroes.global.error.exception.ErrorCode;
 import heroes.global.util.CompanyUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static heroes.global.common.constants.PresignedUrlConstants.*;
-
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class CompanyService {
     private final PresignedUrlService presignedUrlService;
-    private final CompanyRepository companyRepository;
     private final CompanyUtil companyUtil;
 
     public List<PresignedUrlIssueResponse> getImageUploadUrl(
-            @EnumValue(enumClass = ImageType.class, message = "결제 유형이 잘못되었습니다.", ignoreCase = true)
+            @EnumValue(enumClass = ImageType.class, message = "이미지 유형이 잘못되었습니다.", ignoreCase = true)
             String imageType,
             int size) {
         Company currentCompany = companyUtil.getCurrentCompany();
@@ -36,9 +40,20 @@ public class CompanyService {
                     .mapToObj(i -> presignedUrlService.generatePresignedUrl(
                             COMPANY_DIRECTORY + COMPANY_SUB_DIRECTORY + currentCompany.getId().toString() + SLASH + i))
                     .collect(Collectors.toList());
-            default -> throw new IllegalArgumentException("Invalid imageType: " + imageType);
+            case "MENU" -> List.of(presignedUrlService.generatePresignedUrl(
+                    COMPANY_DIRECTORY + COMPANY_MENU_DIRECTORY + currentCompany.getId().toString()));
+            default -> throw new CustomException(ErrorCode.INVALID_IMAGETYPE);
         };
     }
 
 
+    public CompanyCreateResponse updateCompany(CompanyCreateRequest request) {
+        // 기업 존재 여부 확인
+        Company company = companyUtil.getCurrentCompany();
+
+        // 과거 기업의 정보를 수정한다.
+        company.updateCompany(request);
+
+        return new CompanyCreateResponse(company.getId());
+    }
 }

--- a/src/main/java/heroes/domain/company/application/CompanyService.java
+++ b/src/main/java/heroes/domain/company/application/CompanyService.java
@@ -4,8 +4,9 @@ import heroes.domain.common.presignedurl.application.PresignedUrlService;
 import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
 import heroes.domain.company.domain.Company;
 import heroes.domain.company.dto.request.CompanyCreateRequest;
+import heroes.domain.company.dto.request.CompanyUpdateRequest;
 import heroes.domain.company.dto.request.ImageType;
-import heroes.domain.company.dto.response.CompanyCreateResponse;
+import heroes.domain.company.dto.response.CompanyChangeResponse;
 import heroes.domain.companyhour.domain.CompanyHour;
 import heroes.domain.companyhour.domain.DayOfWeek;
 import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
@@ -51,15 +52,26 @@ public class CompanyService {
     }
 
 
-    public CompanyCreateResponse updateCompany(CompanyCreateRequest request) {
+    public CompanyChangeResponse createCompany(CompanyCreateRequest request) {
         // 기업 존재 여부 확인
         Company company = companyUtil.getCurrentCompany();
 
         // 과거 기업의 정보를 수정한다.
-        company.updateCompany(request);
-        updateCompanyHours(company, request);
+        company.createCompany(request);
+        updateCompanyHours(company, request.getCompanyHourCreateRequestList());
 
-        return new CompanyCreateResponse(company.getId());
+        return new CompanyChangeResponse(company.getId());
+    }
+
+    public CompanyChangeResponse updateCompany(CompanyUpdateRequest request) {
+        // 기업 존재 여부 확인
+        Company company = companyUtil.getCurrentCompany();
+
+        // 가게 이름을 제외한 기업 정보 수정 가능
+        company.updateCompany(request);
+        updateCompanyHours(company, request.getCompanyHourCreateRequestList());
+
+        return new CompanyChangeResponse(company.getId());
     }
 
     private List<CompanyHour> buildCompanyHourList(List<CompanyHourCreateRequest> hourRequests, Company company) {
@@ -75,13 +87,14 @@ public class CompanyService {
         }
         return hours;
     }
+
     private void setCompanyHours(Company company, List<CompanyHour> newHours) {
         company.getHours().clear();
         company.getHours().addAll(newHours);
     }
 
-    private void updateCompanyHours(Company company, CompanyCreateRequest request) {
-        List<CompanyHour> newHours = buildCompanyHourList(request.getCompanyHourCreateRequestList(), company);
+    private void updateCompanyHours(Company company, List<CompanyHourCreateRequest> hourRequests) {
+        List<CompanyHour> newHours = buildCompanyHourList(hourRequests, company);
         setCompanyHours(company, newHours);
     }
 }

--- a/src/main/java/heroes/domain/company/application/CompanyService.java
+++ b/src/main/java/heroes/domain/company/application/CompanyService.java
@@ -53,7 +53,31 @@ public class CompanyService {
 
         // 과거 기업의 정보를 수정한다.
         company.updateCompany(request);
+        updateCompanyHours(company, request);
 
         return new CompanyCreateResponse(company.getId());
+    }
+
+    private List<CompanyHour> buildCompanyHourList(List<CompanyHourCreateRequest> hourRequests, Company company) {
+        List<CompanyHour> hours = new ArrayList<>();
+        for (CompanyHourCreateRequest hourRequest : hourRequests) {
+            hours.add(
+                    CompanyHour.buildCompanyHour(
+                            DayOfWeek.valueOf(hourRequest.getDayOfWeek()),
+                            hourRequest.getStartTime(),
+                            hourRequest.getEndTime(),
+                            company
+                    ));
+        }
+        return hours;
+    }
+    private void setCompanyHours(Company company, List<CompanyHour> newHours) {
+        company.getHours().clear();
+        company.getHours().addAll(newHours);
+    }
+
+    private void updateCompanyHours(Company company, CompanyCreateRequest request) {
+        List<CompanyHour> newHours = buildCompanyHourList(request.getCompanyHourCreateRequestList(), company);
+        setCompanyHours(company, newHours);
     }
 }

--- a/src/main/java/heroes/domain/company/domain/Company.java
+++ b/src/main/java/heroes/domain/company/domain/Company.java
@@ -2,7 +2,10 @@ package heroes.domain.company.domain;
 
 import heroes.domain.atmosphere.domain.CompanyAtmosphere;
 import heroes.domain.bookmark.domain.CompanyBookmark;
+import heroes.domain.company.dto.request.CompanyCreateRequest;
 import heroes.domain.companyhour.domain.CompanyHour;
+import heroes.domain.companyhour.domain.DayOfWeek;
+import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
 import heroes.domain.member.domain.District;
 import heroes.domain.review.domain.CompanyReview;
 import heroes.domain.sublevel.domain.CompanySubLevel;
@@ -37,16 +40,15 @@ public class Company {
 
     private String addressDetail;
 
-    private String companyDescription;
-
     @Column(length = 100)
     private String phoneNumber;
 
-    private String mapUrl;
+    private String companyDescription;
+
+    private String companyUrl;
 
     @Embedded
     private CompanyImageUrl companyImageUrl;
-
 
     @Builder.Default
     @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -70,5 +72,36 @@ public class Company {
 
     public static Company createEmptyCompany() {
         return Company.builder().build();
+    }
+
+    public void updateCompany(CompanyCreateRequest request) {
+        this.companyName = request.getCompanyName();
+        this.address = request.getAddress();
+        this.addressDetail = request.getAddressDetail();
+        this.phoneNumber = request.getPhoneNumber();
+        this.companyDescription = request.getCompanyDescription();
+        this.companyUrl = request.getCompanyUrl();
+        setCompanyHours(buildCompanyHourList(request));
+        // TODO : atmosphere, companyType enum type 변경 후 수정 예정
+        this.companyImageUrl = CompanyImageUrl.createCompanyImageUrl(request.getCompanyMainImageUrl(), request.getCompanySubImageUrlList(), request.getCompanyMenuImageUrl());
+    }
+
+    private void setCompanyHours(List<CompanyHour> newHours) {
+        this.hours.clear();
+        this.hours.addAll(newHours);
+    }
+
+    private List<CompanyHour> buildCompanyHourList(CompanyCreateRequest request) {
+        List<CompanyHour> hours = new ArrayList<>();
+        for (CompanyHourCreateRequest hourRequest : request.getCompanyHourCreateRequestList()) {
+            hours.add(
+                    CompanyHour.buildCompanyHour(
+                            DayOfWeek.valueOf(hourRequest.getDayOfWeek()),
+                            hourRequest.getStartTime(),
+                            hourRequest.getEndTime(),
+                            this
+                    ));
+        }
+        return hours;
     }
 }

--- a/src/main/java/heroes/domain/company/domain/Company.java
+++ b/src/main/java/heroes/domain/company/domain/Company.java
@@ -3,6 +3,7 @@ package heroes.domain.company.domain;
 import heroes.domain.atmosphere.domain.CompanyAtmosphere;
 import heroes.domain.bookmark.domain.CompanyBookmark;
 import heroes.domain.company.dto.request.CompanyCreateRequest;
+import heroes.domain.company.dto.request.CompanyUpdateRequest;
 import heroes.domain.companyhour.domain.CompanyHour;
 import heroes.domain.member.domain.District;
 import heroes.domain.review.domain.CompanyReview;
@@ -72,8 +73,18 @@ public class Company {
         return Company.builder().build();
     }
 
-    public void updateCompany(CompanyCreateRequest request) {
+    public void createCompany(CompanyCreateRequest request) {
         this.companyName = request.getCompanyName();
+        this.address = request.getAddress();
+        this.addressDetail = request.getAddressDetail();
+        this.phoneNumber = request.getPhoneNumber();
+        this.companyDescription = request.getCompanyDescription();
+        this.companyUrl = request.getCompanyUrl();
+        // TODO : atmosphere, companyType enum type 변경 후 수정 예정
+        this.companyImageUrl = CompanyImageUrl.createCompanyImageUrl(request.getCompanyMainImageUrl(), request.getCompanySubImageUrlList(), request.getCompanyMenuImageUrl());
+    }
+
+    public void updateCompany(CompanyUpdateRequest request) {
         this.address = request.getAddress();
         this.addressDetail = request.getAddressDetail();
         this.phoneNumber = request.getPhoneNumber();

--- a/src/main/java/heroes/domain/company/domain/Company.java
+++ b/src/main/java/heroes/domain/company/domain/Company.java
@@ -4,8 +4,6 @@ import heroes.domain.atmosphere.domain.CompanyAtmosphere;
 import heroes.domain.bookmark.domain.CompanyBookmark;
 import heroes.domain.company.dto.request.CompanyCreateRequest;
 import heroes.domain.companyhour.domain.CompanyHour;
-import heroes.domain.companyhour.domain.DayOfWeek;
-import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
 import heroes.domain.member.domain.District;
 import heroes.domain.review.domain.CompanyReview;
 import heroes.domain.sublevel.domain.CompanySubLevel;
@@ -81,27 +79,7 @@ public class Company {
         this.phoneNumber = request.getPhoneNumber();
         this.companyDescription = request.getCompanyDescription();
         this.companyUrl = request.getCompanyUrl();
-        setCompanyHours(buildCompanyHourList(request));
         // TODO : atmosphere, companyType enum type 변경 후 수정 예정
         this.companyImageUrl = CompanyImageUrl.createCompanyImageUrl(request.getCompanyMainImageUrl(), request.getCompanySubImageUrlList(), request.getCompanyMenuImageUrl());
-    }
-
-    private void setCompanyHours(List<CompanyHour> newHours) {
-        this.hours.clear();
-        this.hours.addAll(newHours);
-    }
-
-    private List<CompanyHour> buildCompanyHourList(CompanyCreateRequest request) {
-        List<CompanyHour> hours = new ArrayList<>();
-        for (CompanyHourCreateRequest hourRequest : request.getCompanyHourCreateRequestList()) {
-            hours.add(
-                    CompanyHour.buildCompanyHour(
-                            DayOfWeek.valueOf(hourRequest.getDayOfWeek()),
-                            hourRequest.getStartTime(),
-                            hourRequest.getEndTime(),
-                            this
-                    ));
-        }
-        return hours;
     }
 }

--- a/src/main/java/heroes/domain/company/domain/Company.java
+++ b/src/main/java/heroes/domain/company/domain/Company.java
@@ -7,9 +7,10 @@ import heroes.domain.member.domain.District;
 import heroes.domain.review.domain.CompanyReview;
 import heroes.domain.sublevel.domain.CompanySubLevel;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.util.ArrayList;
 import java.util.List;
-import lombok.*;
 
 @Entity
 @Getter
@@ -30,6 +31,8 @@ public class Company {
     @Enumerated(value = EnumType.STRING)
     private District district;
 
+    private CompanyType companyType;
+
     private String address;
 
     private String addressDetail;
@@ -40,7 +43,10 @@ public class Company {
     private String phoneNumber;
 
     private String mapUrl;
-    private String mainImageUrl;
+
+    @Embedded
+    private CompanyImageUrl companyImageUrl;
+
 
     @Builder.Default
     @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/heroes/domain/company/domain/CompanyImageUrl.java
+++ b/src/main/java/heroes/domain/company/domain/CompanyImageUrl.java
@@ -1,5 +1,6 @@
 package heroes.domain.company.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,9 +12,16 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class CompanyImageUrl {
+    @Column(length = 1000)
     private String mainImageUrl;
+
+    @Column(length = 1000)
     private String firstSubImageUrl;
+
+    @Column(length = 1000)
     private String secondSubImageUrl;
+
+    @Column(length = 1000)
     private String menuImageUrl;
 
     @Builder

--- a/src/main/java/heroes/domain/company/domain/CompanyImageUrl.java
+++ b/src/main/java/heroes/domain/company/domain/CompanyImageUrl.java
@@ -1,8 +1,11 @@
 package heroes.domain.company.domain;
 
 import jakarta.persistence.Embeddable;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Embeddable
 @Getter
@@ -11,4 +14,22 @@ public class CompanyImageUrl {
     private String mainImageUrl;
     private String firstSubImageUrl;
     private String secondSubImageUrl;
+    private String menuImageUrl;
+
+    @Builder
+    public CompanyImageUrl(String mainImageUrl, String firstSubImageUrl, String secondSubImageUrl, String menuImageUrl) {
+        this.mainImageUrl = mainImageUrl;
+        this.firstSubImageUrl = firstSubImageUrl;
+        this.secondSubImageUrl = secondSubImageUrl;
+        this.menuImageUrl = menuImageUrl;
+    }
+
+    public static CompanyImageUrl createCompanyImageUrl(String mainImageUrl, List<String> companySubImageUrlList, String menuImageUrl) {
+        return CompanyImageUrl.builder()
+                .mainImageUrl(mainImageUrl)
+                .firstSubImageUrl(companySubImageUrlList.get(0))
+                .secondSubImageUrl(companySubImageUrlList.get(1))
+                .menuImageUrl(menuImageUrl)
+                .build();
+    }
 }

--- a/src/main/java/heroes/domain/company/domain/CompanyImageUrl.java
+++ b/src/main/java/heroes/domain/company/domain/CompanyImageUrl.java
@@ -1,0 +1,14 @@
+package heroes.domain.company.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class CompanyImageUrl {
+    private String mainImageUrl;
+    private String firstSubImageUrl;
+    private String secondSubImageUrl;
+}

--- a/src/main/java/heroes/domain/company/domain/CompanyType.java
+++ b/src/main/java/heroes/domain/company/domain/CompanyType.java
@@ -1,0 +1,17 @@
+package heroes.domain.company.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CompanyType {
+
+    RESTAURANT("식당"),
+    CAFE("카페"),
+    KIDSCAFE("키즈카페"),
+    PLAYGROUND("놀이시설"),
+    ETC("기타")
+    ;
+    private final String value;
+}

--- a/src/main/java/heroes/domain/company/dto/request/CompanyCreateRequest.java
+++ b/src/main/java/heroes/domain/company/dto/request/CompanyCreateRequest.java
@@ -1,0 +1,35 @@
+package heroes.domain.company.dto.request;
+
+import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+@Schema(description = "기업유저 정보 기입")
+@Getter
+public class CompanyCreateRequest {
+
+    private String companyName;
+
+    private String address;
+
+    private String addressDetail;
+
+    private String phoneNumber;
+
+    private String companyDescription;
+
+    private String companyUrl;
+
+    private List<CompanyHourCreateRequest> companyHourCreateRequestList;
+
+    private List<String> companyTypeList;
+
+    private List<String> atmosphereNameList;
+
+    private String companyMainImageUrl;
+
+    private List<String> companySubImageUrlList;
+
+    private String companyMenuImageUrl;
+}

--- a/src/main/java/heroes/domain/company/dto/request/CompanyCreateRequest.java
+++ b/src/main/java/heroes/domain/company/dto/request/CompanyCreateRequest.java
@@ -2,6 +2,7 @@ package heroes.domain.company.dto.request;
 
 import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.util.List;
@@ -9,27 +10,45 @@ import java.util.List;
 @Getter
 public class CompanyCreateRequest {
 
+    @NotNull(message = "기업명은 비워둘 수 없습니다.")
+    @Schema(description = "기업명", defaultValue = "히어로즈")
     private String companyName;
 
+    @NotNull(message = "주소는 비워둘 수 없습니다.")
+    @Schema(description = "주소", defaultValue = "서울특별시 동작구 여의대방로54길 18")
     private String address;
 
+    @NotNull(message = "상세 주소는 비워둘 수 없습니다.")
+    @Schema(description = "상세 주소", defaultValue = "1층")
     private String addressDetail;
 
+    @NotNull(message = "전화번호는 비워둘 수 없습니다.")
+    @Schema(description = "전화번호", defaultValue = "02-810-5000")
     private String phoneNumber;
 
+    @Schema(description = "기업소개", defaultValue = "아이가 행복하게 뛰놀수 있는 카페가 있습니다.")
     private String companyDescription;
 
+    @Schema(description = "기업관련url", defaultValue = "https://www.seoulwomen.or.kr/sfwf/main/index.do")
     private String companyUrl;
 
+    @Schema(description = "운영시간")
     private List<CompanyHourCreateRequest> companyHourCreateRequestList;
 
+    @Schema(description = "기업타입 리스트", defaultValue = "[\"CAFE\", \"RESTAURANT\"]")
     private List<String> companyTypeList;
 
+    @Schema(description = "분위기 리스트", defaultValue = "[]")
+    // TODO : 분위기 Enum 정해진 후 defaultValue 넣기
     private List<String> atmosphereNameList;
 
+    @Schema(description = "기업 메인 이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/main/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
     private String companyMainImageUrl;
 
+//    @Schema(description = "기업 서브 이미지", defaultValue = "[\"https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/1/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\",https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/2/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\" ]")
+    @Schema(description = "기업 서브 이미지")
     private List<String> companySubImageUrlList;
 
+    @Schema(description = "기업 메뉴이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/menu/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
     private String companyMenuImageUrl;
 }

--- a/src/main/java/heroes/domain/company/dto/request/CompanyUpdateRequest.java
+++ b/src/main/java/heroes/domain/company/dto/request/CompanyUpdateRequest.java
@@ -1,0 +1,49 @@
+package heroes.domain.company.dto.request;
+
+import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+@Getter
+public class CompanyUpdateRequest {
+    @NotNull(message = "주소는 비워둘 수 없습니다.")
+    @Schema(description = "주소", defaultValue = "서울특별시 동작구 여의대방로54길 18")
+    private String address;
+
+    @NotNull(message = "상세 주소는 비워둘 수 없습니다.")
+    @Schema(description = "상세 주소", defaultValue = "1층")
+    private String addressDetail;
+
+    @NotNull(message = "전화번호는 비워둘 수 없습니다.")
+    @Schema(description = "전화번호", defaultValue = "02-810-5000")
+    private String phoneNumber;
+
+    @Schema(description = "기업소개", defaultValue = "아이가 행복하게 뛰놀수 있는 카페가 있습니다.")
+    private String companyDescription;
+
+    @Schema(description = "기업관련url", defaultValue = "https://www.seoulwomen.or.kr/sfwf/main/index.do")
+    private String companyUrl;
+
+    @Schema(description = "운영시간")
+    private List<CompanyHourCreateRequest> companyHourCreateRequestList;
+
+    @Schema(description = "기업타입 리스트", defaultValue = "[\"CAFE\", \"RESTAURANT\"]")
+    private List<String> companyTypeList;
+
+    @Schema(description = "분위기 리스트", defaultValue = "[]")
+    // TODO : 분위기 Enum 정해진 후 defaultValue 넣기
+    private List<String> atmosphereNameList;
+
+    @Schema(description = "기업 메인 이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/main/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
+    private String companyMainImageUrl;
+
+    //    @Schema(description = "기업 서브 이미지", defaultValue = "[\"https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/1/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\",https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/2/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\" ]")
+    @Schema(description = "기업 서브 이미지")
+    private List<String> companySubImageUrlList;
+
+    @Schema(description = "기업 메뉴이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/menu/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
+    private String companyMenuImageUrl;
+
+}

--- a/src/main/java/heroes/domain/company/dto/request/ImageType.java
+++ b/src/main/java/heroes/domain/company/dto/request/ImageType.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public enum ImageType {
     MAIN(),
-    SUB();
+    SUB()
 }

--- a/src/main/java/heroes/domain/company/dto/request/ImageType.java
+++ b/src/main/java/heroes/domain/company/dto/request/ImageType.java
@@ -1,0 +1,9 @@
+package heroes.domain.company.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageType {
+    MAIN(),
+    SUB();
+}

--- a/src/main/java/heroes/domain/company/dto/response/CompanyChangeResponse.java
+++ b/src/main/java/heroes/domain/company/dto/response/CompanyChangeResponse.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class CompanyCreateResponse {
+public class CompanyChangeResponse {
 
     @Schema(description = "기업 Id")
     Long companyId;

--- a/src/main/java/heroes/domain/company/dto/response/CompanyCreateResponse.java
+++ b/src/main/java/heroes/domain/company/dto/response/CompanyCreateResponse.java
@@ -1,5 +1,6 @@
 package heroes.domain.company.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CompanyCreateResponse {
+
+    @Schema(description = "기업 Id")
     Long companyId;
 }
 

--- a/src/main/java/heroes/domain/company/dto/response/CompanyCreateResponse.java
+++ b/src/main/java/heroes/domain/company/dto/response/CompanyCreateResponse.java
@@ -1,0 +1,13 @@
+package heroes.domain.company.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CompanyCreateResponse {
+    Long companyId;
+}
+

--- a/src/main/java/heroes/domain/companyhour/domain/CompanyHour.java
+++ b/src/main/java/heroes/domain/companyhour/domain/CompanyHour.java
@@ -2,10 +2,12 @@ package heroes.domain.companyhour.domain;
 
 import heroes.domain.company.domain.Company;
 import jakarta.persistence.*;
-import java.sql.Time;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -19,10 +21,32 @@ public class CompanyHour {
     @Enumerated(value = EnumType.STRING)
     private DayOfWeek dayOfWeek;
 
-    private Time startTime;
-    private Time endTime;
+    private LocalTime startTime;
+    private LocalTime endTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id")
     private Company company;
+
+    @Builder
+    private CompanyHour(
+            DayOfWeek dayOfWeek,
+            LocalTime startTime,
+            LocalTime endTime,
+            Company company
+    ) {
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.company = company;
+    }
+
+    public static CompanyHour buildCompanyHour(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, Company company){
+        return CompanyHour.builder()
+                .dayOfWeek(dayOfWeek)
+                .startTime(startTime)
+                .endTime(endTime)
+                .company(company)
+                .build();
+    }
 }

--- a/src/main/java/heroes/domain/companyhour/dto/CompanyHourCreateRequest.java
+++ b/src/main/java/heroes/domain/companyhour/dto/CompanyHourCreateRequest.java
@@ -1,16 +1,30 @@
 package heroes.domain.companyhour.dto;
 
+import heroes.global.common.validations.EnumValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.DayOfWeek;
 import java.time.LocalTime;
+
+import static heroes.global.common.constants.MessageConstants.INVALID_DAYOFWEEK_MESSAGE;
 
 @Getter
 public class CompanyHourCreateRequest {
+    @NotNull
+    @Schema(description = "요일", defaultValue = "MON")
+    @EnumValue(enumClass = DayOfWeek.class, message = INVALID_DAYOFWEEK_MESSAGE, ignoreCase = true)
     private String dayOfWeek;
 
+    @NotNull
+    @Schema(description = "시작 시간", defaultValue = "10:00")
     @DateTimeFormat(pattern ="HH:mm")
     private LocalTime startTime;
+
+    @NotNull
+    @Schema(description = "종료 시간", defaultValue = "11:00")
     @DateTimeFormat(pattern ="HH:mm")
     private LocalTime endTime;
 }

--- a/src/main/java/heroes/domain/companyhour/dto/CompanyHourCreateRequest.java
+++ b/src/main/java/heroes/domain/companyhour/dto/CompanyHourCreateRequest.java
@@ -1,0 +1,16 @@
+package heroes.domain.companyhour.dto;
+
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalTime;
+
+@Getter
+public class CompanyHourCreateRequest {
+    private String dayOfWeek;
+
+    @DateTimeFormat(pattern ="HH:mm")
+    private LocalTime startTime;
+    @DateTimeFormat(pattern ="HH:mm")
+    private LocalTime endTime;
+}

--- a/src/main/java/heroes/global/common/constants/MessageConstants.java
+++ b/src/main/java/heroes/global/common/constants/MessageConstants.java
@@ -1,0 +1,5 @@
+package heroes.global.common.constants;
+
+public final class MessageConstants {
+    public static final String INVALID_IMAGE_TYPE_MESSAGE = "이미지 유형이 잘못되었습니다.";
+}

--- a/src/main/java/heroes/global/common/constants/MessageConstants.java
+++ b/src/main/java/heroes/global/common/constants/MessageConstants.java
@@ -2,4 +2,5 @@ package heroes.global.common.constants;
 
 public final class MessageConstants {
     public static final String INVALID_IMAGE_TYPE_MESSAGE = "이미지 유형이 잘못되었습니다.";
+    public static final String INVALID_DAYOFWEEK_MESSAGE = "요일 입력이 잘못되었습니다.";
 }

--- a/src/main/java/heroes/global/common/constants/PresignedUrlConstants.java
+++ b/src/main/java/heroes/global/common/constants/PresignedUrlConstants.java
@@ -5,6 +5,7 @@ public final class PresignedUrlConstants {
     public static final String COMPANY_DIRECTORY = "companies/";
     public static final String COMPANY_MAIN_DIRECTORY = "main/";
     public static final String COMPANY_SUB_DIRECTORY = "sub/";
+    public static final String COMPANY_MENU_DIRECTORY = "menu/";
 
 
     public static final String SLASH = "/";

--- a/src/main/java/heroes/global/common/constants/PresignedUrlConstants.java
+++ b/src/main/java/heroes/global/common/constants/PresignedUrlConstants.java
@@ -2,6 +2,10 @@ package heroes.global.common.constants;
 
 public final class PresignedUrlConstants {
     public static final String MEMBER_PROFILE_DIRECTORY = "profile/";
+    public static final String COMPANY_DIRECTORY = "companies/";
+    public static final String COMPANY_MAIN_DIRECTORY = "main/";
+    public static final String COMPANY_SUB_DIRECTORY = "sub/";
+
 
     public static final String SLASH = "/";
 }

--- a/src/main/java/heroes/global/common/validations/EnumValidator.java
+++ b/src/main/java/heroes/global/common/validations/EnumValidator.java
@@ -1,0 +1,34 @@
+package heroes.global.common.validations;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+
+public class EnumValidator implements ConstraintValidator<EnumValue, String> {
+    private EnumValue enumValue;
+
+    @Override
+    public void initialize(final EnumValue constraintAnnotation) {
+        this.enumValue = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(final String value, final ConstraintValidatorContext context) {
+        final Enum<?>[] enumConstants = this.enumValue.enumClass().getEnumConstants();
+        if (enumConstants == null) {
+            return false;
+        }
+
+        return Arrays.stream(enumConstants)
+                .anyMatch(enumConstant -> convertible(value, enumConstant) || convertibleIgnoreCase(value, enumConstant));
+    }
+
+    private boolean convertibleIgnoreCase(final String value, final Enum<?> enumConstant) {
+        return this.enumValue.ignoreCase() && value.trim().equalsIgnoreCase(enumConstant.name());
+    }
+
+    private boolean convertible(final String value, final Enum<?> enumConstant) {
+        return value.trim().equals(enumConstant.name());
+    }
+}

--- a/src/main/java/heroes/global/common/validations/EnumValue.java
+++ b/src/main/java/heroes/global/common/validations/EnumValue.java
@@ -1,0 +1,20 @@
+package heroes.global.common.validations;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.RetentionPolicy;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValidator.class)
+public @interface EnumValue {
+    Class<? extends Enum<?>> enumClass();
+    String message() default "";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    boolean ignoreCase() default false;
+}

--- a/src/main/java/heroes/global/error/exception/ErrorCode.java
+++ b/src/main/java/heroes/global/error/exception/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
     COMPANY_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "HS4042", "해당 기업에 대한 북마크가 적용되지 않았습니다."),
 
     NICKNAME_ALREADY_EXIST(HttpStatus.CONFLICT, "HS4090", "이미 존재하는 닉네임입니다."),
-    COMPANY_BOOKMARK_ALREADY_EXIST(HttpStatus.CONFLICT, "HS4091", "이미 북마크가 적용되었습니다.");
+    COMPANY_BOOKMARK_ALREADY_EXIST(HttpStatus.CONFLICT, "HS4091", "이미 북마크가 적용되었습니다."),
+
+    INVALID_IMAGETYPE(HttpStatus.UNPROCESSABLE_ENTITY, "HS4221", "이미지 유형이 잘못되었습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/heroes/global/error/exception/ErrorCode.java
+++ b/src/main/java/heroes/global/error/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "HS4040", "해당 회원을 찾을 수 없습니다."),
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "HS4041", "해당 기업을 찾을 수 없습니다."),
+    COMPANY_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "HS4042", "해당 기업에 대한 북마크가 적용되지 않았습니다."),
 
     NICKNAME_ALREADY_EXIST(HttpStatus.CONFLICT, "HS4090", "이미 존재하는 닉네임입니다."),
     COMPANY_BOOKMARK_ALREADY_EXIST(HttpStatus.CONFLICT, "HS4091", "이미 북마크가 적용되었습니다.");

--- a/src/main/java/heroes/global/util/CompanyUtil.java
+++ b/src/main/java/heroes/global/util/CompanyUtil.java
@@ -1,0 +1,22 @@
+package heroes.global.util;
+
+import heroes.domain.company.dao.CompanyRepository;
+import heroes.domain.company.domain.Company;
+import heroes.domain.member.dao.MemberRepository;
+import heroes.global.error.exception.CustomException;
+import heroes.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CompanyUtil {
+    private final MemberUtil memberUtil;
+    private final CompanyRepository companyRepository;
+
+    public Company getCurrentCompany() {
+        return companyRepository
+                .findById(memberUtil.getCurrentMember().getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+    }
+}

--- a/src/main/java/heroes/global/util/CompanyUtil.java
+++ b/src/main/java/heroes/global/util/CompanyUtil.java
@@ -16,7 +16,7 @@ public class CompanyUtil {
 
     public Company getCurrentCompany() {
         return companyRepository
-                .findById(memberUtil.getCurrentMember().getId())
+                .findById(memberUtil.getCurrentMember().getCompany().getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 💡 Issue
- #34  

## 📌 Work Description
### 기업 회원 정보 수정 로직 구현
#### 기업 회원 Entity 수정 

1. String companyUrl : 기업 관련 url 필드
2. CompanyImageUrl compnayImageUrl : 기업 관련 이미지 url (메인 이미지, 서브 이미지 1, 서브 이미지2, 메뉴 이미지)
3. CompanyType comanyType : 기업 종류 Enum 필드

#### 기업 회원 관련 이미지 url 얻는 로직을 구현하였습니다. 
1. MAIN, SUB, MENU type으로 구분하여 s3 url 생성할 수 있습니다. 
2. FIELD, PARAMETER 의 EnumType 유효성 체크를 할 수 있습니다. 

####  기업 회원 정보 수정 로직 구현하였습니다. 

## 📝 Reference
- https://velog.io/@kmw89891/DTO-enum-%ED%95%84%EB%93%9C-%EC%82%AC%EC%9A%A9

## 📚 Etc
- X