### PR TITLE
[FIX] 기업 분위기 enum화 및 테이블 설정

### DIFF
--- a/src/main/java/heroes/domain/atmosphere/domain/Atmosphere.java
+++ b/src/main/java/heroes/domain/atmosphere/domain/Atmosphere.java
@@ -1,19 +1,16 @@
 package heroes.domain.atmosphere.domain;
 
-import jakarta.persistence.*;
-import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Atmosphere {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "atmosphere_id")
-    private Long id;
+@AllArgsConstructor
+public enum Atmosphere {
+    NEAT("깔끔한"),
+    ENERGETIC("활기찬"),
+    FUN("재미있는"),
+    SOFT("부드러운"),
+    CALM("차분한");
 
-    @Column(length = 100)
-    private String atmosphereName;
+    private String value;
 }

--- a/src/main/java/heroes/domain/atmosphere/domain/CompanyAtmosphere.java
+++ b/src/main/java/heroes/domain/atmosphere/domain/CompanyAtmosphere.java
@@ -2,9 +2,7 @@ package heroes.domain.atmosphere.domain;
 
 import heroes.domain.company.domain.Company;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -12,14 +10,22 @@ import lombok.NoArgsConstructor;
 public class CompanyAtmosphere {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "company_atmosphere_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "company_id")
     private Company company;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "atmosphere_id")
+    @Enumerated(EnumType.STRING)
     private Atmosphere atmosphere;
+
+    @Builder
+    private CompanyAtmosphere(Company company, Atmosphere atmosphere) {
+        this.company = company;
+        this.atmosphere = atmosphere;
+    }
+
+    public static CompanyAtmosphere createAtmosphere(Company company, Atmosphere atmosphere) {
+        return CompanyAtmosphere.builder().company(company).atmosphere(atmosphere).build();
+    }
 }

--- a/src/main/java/heroes/domain/company/domain/Company.java
+++ b/src/main/java/heroes/domain/company/domain/Company.java
@@ -5,14 +5,13 @@ import heroes.domain.bookmark.domain.CompanyBookmark;
 import heroes.domain.company.dto.request.CompanyCreateRequest;
 import heroes.domain.company.dto.request.CompanyUpdateRequest;
 import heroes.domain.companyhour.domain.CompanyHour;
-import heroes.domain.member.domain.District;
 import heroes.domain.review.domain.CompanyReview;
 import heroes.domain.sublevel.domain.CompanySubLevel;
+import heroes.domain.type.domain.CompanyType;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.*;
 
 @Entity
 @Getter
@@ -30,11 +29,6 @@ public class Company {
 
     private int finalLevel;
 
-    @Enumerated(value = EnumType.STRING)
-    private District district;
-
-    private CompanyType companyType;
-
     private String address;
 
     private String addressDetail;
@@ -46,16 +40,11 @@ public class Company {
 
     private String companyUrl;
 
-    @Embedded
-    private CompanyImageUrl companyImageUrl;
+    @Embedded private CompanyImageUrl companyImageUrl;
 
     @Builder.Default
     @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CompanyBookmark> bookmarks = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<CompanyAtmosphere> atmospheres = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -69,6 +58,14 @@ public class Company {
     @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CompanySubLevel> subLevels = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CompanyType> typeList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CompanyAtmosphere> atmosphereList = new ArrayList<>();
+
     public static Company createEmptyCompany() {
         return Company.builder().build();
     }
@@ -80,8 +77,19 @@ public class Company {
         this.phoneNumber = request.getPhoneNumber();
         this.companyDescription = request.getCompanyDescription();
         this.companyUrl = request.getCompanyUrl();
-        // TODO : atmosphere, companyType enum type 변경 후 수정 예정
-        this.companyImageUrl = CompanyImageUrl.createCompanyImageUrl(request.getCompanyMainImageUrl(), request.getCompanySubImageUrlList(), request.getCompanyMenuImageUrl());
+        this.companyImageUrl =
+                CompanyImageUrl.createCompanyImageUrl(
+                        request.getCompanyMainImageUrl(),
+                        request.getCompanySubImageUrlList(),
+                        request.getCompanyMenuImageUrl());
+
+        request.getTypeList()
+                .forEach(type -> this.typeList.add(CompanyType.createType(this, type)));
+        request.getAtmosphereNameList()
+                .forEach(
+                        atmosphere ->
+                                this.atmosphereList.add(
+                                        CompanyAtmosphere.createAtmosphere(this, atmosphere)));
     }
 
     public void updateCompany(CompanyUpdateRequest request) {
@@ -90,7 +98,21 @@ public class Company {
         this.phoneNumber = request.getPhoneNumber();
         this.companyDescription = request.getCompanyDescription();
         this.companyUrl = request.getCompanyUrl();
-        // TODO : atmosphere, companyType enum type 변경 후 수정 예정
-        this.companyImageUrl = CompanyImageUrl.createCompanyImageUrl(request.getCompanyMainImageUrl(), request.getCompanySubImageUrlList(), request.getCompanyMenuImageUrl());
+        this.companyImageUrl =
+                CompanyImageUrl.createCompanyImageUrl(
+                        request.getCompanyMainImageUrl(),
+                        request.getCompanySubImageUrlList(),
+                        request.getCompanyMenuImageUrl());
+
+        this.typeList.clear();
+        request.getTypeList()
+                .forEach(type -> this.typeList.add(CompanyType.createType(this, type)));
+
+        this.atmosphereList.clear();
+        request.getAtmosphereNameList()
+                .forEach(
+                        atmosphere ->
+                                this.atmosphereList.add(
+                                        CompanyAtmosphere.createAtmosphere(this, atmosphere)));
     }
 }

--- a/src/main/java/heroes/domain/company/dto/request/CompanyCreateRequest.java
+++ b/src/main/java/heroes/domain/company/dto/request/CompanyCreateRequest.java
@@ -1,11 +1,13 @@
 package heroes.domain.company.dto.request;
 
+import heroes.domain.atmosphere.domain.Atmosphere;
 import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
+import heroes.domain.type.domain.Type;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.Getter;
 
-import java.util.List;
 @Schema(description = "기업유저 정보 기입")
 @Getter
 public class CompanyCreateRequest {
@@ -29,26 +31,34 @@ public class CompanyCreateRequest {
     @Schema(description = "기업소개", defaultValue = "아이가 행복하게 뛰놀수 있는 카페가 있습니다.")
     private String companyDescription;
 
-    @Schema(description = "기업관련url", defaultValue = "https://www.seoulwomen.or.kr/sfwf/main/index.do")
+    @Schema(
+            description = "기업관련url",
+            defaultValue = "https://www.seoulwomen.or.kr/sfwf/main/index.do")
     private String companyUrl;
 
     @Schema(description = "운영시간")
     private List<CompanyHourCreateRequest> companyHourCreateRequestList;
 
     @Schema(description = "기업타입 리스트", defaultValue = "[\"CAFE\", \"RESTAURANT\"]")
-    private List<String> companyTypeList;
+    private List<Type> typeList;
 
-    @Schema(description = "분위기 리스트", defaultValue = "[]")
-    // TODO : 분위기 Enum 정해진 후 defaultValue 넣기
-    private List<String> atmosphereNameList;
+    @Schema(description = "분위기 리스트", defaultValue = "[\"ENERGETIC\", \"FUN\", \"SOFT\", \"CALM\"]")
+    private List<Atmosphere> atmosphereNameList;
 
-    @Schema(description = "기업 메인 이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/main/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
+    @Schema(
+            description = "기업 메인 이미지",
+            defaultValue =
+                    "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/main/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
     private String companyMainImageUrl;
 
-//    @Schema(description = "기업 서브 이미지", defaultValue = "[\"https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/1/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\",https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/2/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\" ]")
+    //    @Schema(description = "기업 서브 이미지", defaultValue =
+    // "[\"https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/1/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\",https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/2/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\" ]")
     @Schema(description = "기업 서브 이미지")
     private List<String> companySubImageUrlList;
 
-    @Schema(description = "기업 메뉴이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/menu/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
+    @Schema(
+            description = "기업 메뉴이미지",
+            defaultValue =
+                    "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/menu/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
     private String companyMenuImageUrl;
 }

--- a/src/main/java/heroes/domain/company/dto/request/CompanyUpdateRequest.java
+++ b/src/main/java/heroes/domain/company/dto/request/CompanyUpdateRequest.java
@@ -1,11 +1,13 @@
 package heroes.domain.company.dto.request;
 
+import heroes.domain.atmosphere.domain.Atmosphere;
 import heroes.domain.companyhour.dto.CompanyHourCreateRequest;
+import heroes.domain.type.domain.Type;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.Getter;
 
-import java.util.List;
 @Getter
 public class CompanyUpdateRequest {
     @NotNull(message = "주소는 비워둘 수 없습니다.")
@@ -23,27 +25,34 @@ public class CompanyUpdateRequest {
     @Schema(description = "기업소개", defaultValue = "아이가 행복하게 뛰놀수 있는 카페가 있습니다.")
     private String companyDescription;
 
-    @Schema(description = "기업관련url", defaultValue = "https://www.seoulwomen.or.kr/sfwf/main/index.do")
+    @Schema(
+            description = "기업관련url",
+            defaultValue = "https://www.seoulwomen.or.kr/sfwf/main/index.do")
     private String companyUrl;
 
     @Schema(description = "운영시간")
     private List<CompanyHourCreateRequest> companyHourCreateRequestList;
 
     @Schema(description = "기업타입 리스트", defaultValue = "[\"CAFE\", \"RESTAURANT\"]")
-    private List<String> companyTypeList;
+    private List<Type> typeList;
 
-    @Schema(description = "분위기 리스트", defaultValue = "[]")
-    // TODO : 분위기 Enum 정해진 후 defaultValue 넣기
-    private List<String> atmosphereNameList;
+    @Schema(description = "분위기 리스트", defaultValue = "[\"ENERGETIC\", \"FUN\", \"SOFT\", \"CALM\"]")
+    private List<Atmosphere> atmosphereNameList;
 
-    @Schema(description = "기업 메인 이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/main/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
+    @Schema(
+            description = "기업 메인 이미지",
+            defaultValue =
+                    "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/main/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
     private String companyMainImageUrl;
 
-    //    @Schema(description = "기업 서브 이미지", defaultValue = "[\"https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/1/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\",https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/2/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\" ]")
+    //    @Schema(description = "기업 서브 이미지", defaultValue =
+    // "[\"https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/1/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\",https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/sub/2/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073\" ]")
     @Schema(description = "기업 서브 이미지")
     private List<String> companySubImageUrlList;
 
-    @Schema(description = "기업 메뉴이미지", defaultValue = "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/menu/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
+    @Schema(
+            description = "기업 메뉴이미지",
+            defaultValue =
+                    "https://heroes-presigned.s3.ap-northeast-2.amazonaws.com/companies/menu/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240813T040424Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIAVRUVVZYYFMRNKFKI%2F20240813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=04c8c6b520576ea1b0d5c659a5927bae1667d7e71cefbbf34d35bdac61482073")
     private String companyMenuImageUrl;
-
 }

--- a/src/main/java/heroes/domain/type/domain/CompanyType.java
+++ b/src/main/java/heroes/domain/type/domain/CompanyType.java
@@ -1,0 +1,34 @@
+package heroes.domain.type.domain;
+
+import heroes.domain.company.domain.Company;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "company_id")
+    private Company company;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @Builder
+    private CompanyType(Company company, Type type) {
+        this.company = company;
+        this.type = type;
+    }
+
+    public static CompanyType createType(Company company, Type type) {
+        return CompanyType.builder().company(company).type(type).build();
+    }
+}

--- a/src/main/java/heroes/domain/type/domain/Type.java
+++ b/src/main/java/heroes/domain/type/domain/Type.java
@@ -1,17 +1,15 @@
-package heroes.domain.company.domain;
+package heroes.domain.type.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum CompanyType {
-
+public enum Type {
     RESTAURANT("식당"),
     CAFE("카페"),
     KIDSCAFE("키즈카페"),
     PLAYGROUND("놀이시설"),
-    ETC("기타")
-    ;
+    ETC("기타");
     private final String value;
 }


### PR DESCRIPTION
## 💡 Issue
- #42 

## 📌 Work Description
### 기업 분위기를 테이블이 아닌 enum으로 변경
- 기업이 분위기를 여러 개 보유할 수 있어 테이블화를 진행하였습니다.
### 기업 종류에 대한 테이블 추가
- 기업이 종류를 여러 개 보유할 수 있어 테이블화를 진행하였습니다.
### 기타 작업
- reqeust dto에서 기업 종류 및 분위기를 enum의 리스트로 받도록 설정했습니다.
- 종류 및 분위기에 대한 디렉토리 분류를 진행하였습니다.
- 기업 엔티티에 지역구 속성이 필요하지 않아 제거하였습니다. 

## 📝 Reference
- X

## 📚 Etc
- X