### PR TITLE
[FEAT] 일반 유저 정보 조회

### DIFF
--- a/src/main/java/heroes/domain/member/api/MemberController.java
+++ b/src/main/java/heroes/domain/member/api/MemberController.java
@@ -33,7 +33,7 @@ public class MemberController {
 
     @Operation(summary = "일반 회원 정보 조회", description = "일반 유저 정보를 조회합니다.")
     @GetMapping("/info")
-    public MemberInfoResponse updateMemberInfo() {
+    public MemberInfoResponse getMemberInfo() {
         return memberService.getMemberInfo();
     }
 }

--- a/src/main/java/heroes/domain/member/api/MemberController.java
+++ b/src/main/java/heroes/domain/member/api/MemberController.java
@@ -3,6 +3,7 @@ package heroes.domain.member.api;
 import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
 import heroes.domain.member.application.MemberService;
 import heroes.domain.member.dto.request.MemberUpdateRequest;
+import heroes.domain.member.dto.response.MemberInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +29,11 @@ public class MemberController {
     public ResponseEntity<Void> updateMemberInfo(@RequestBody MemberUpdateRequest request) {
         memberService.updateMember(request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Operation(summary = "일반 회원 정보 조회", description = "일반 유저 정보를 조회합니다.")
+    @GetMapping("/info")
+    public MemberInfoResponse updateMemberInfo() {
+        return memberService.getMemberInfo();
     }
 }

--- a/src/main/java/heroes/domain/member/application/MemberService.java
+++ b/src/main/java/heroes/domain/member/application/MemberService.java
@@ -8,6 +8,7 @@ import heroes.domain.common.presignedurl.dto.response.PresignedUrlIssueResponse;
 import heroes.domain.member.dao.MemberRepository;
 import heroes.domain.member.domain.Member;
 import heroes.domain.member.dto.request.MemberUpdateRequest;
+import heroes.domain.member.dto.response.MemberInfoResponse;
 import heroes.global.error.exception.CustomException;
 import heroes.global.error.exception.ErrorCode;
 import heroes.global.util.MemberUtil;
@@ -38,6 +39,14 @@ public class MemberService {
                         + MEMBER_PROFILE_DIRECTORY
                         + currentMember.getId().toString();
         currentMember.updateMemberInfo(request, profileUrl);
+    }
+
+    public MemberInfoResponse getMemberInfo() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        return new MemberInfoResponse(
+                currentMember.getProfileUrl(),
+                currentMember.getNickname(),
+                currentMember.getOauthInfo().getOauthEmail());
     }
 
     private void validateNicknameExist(MemberUpdateRequest request) {

--- a/src/main/java/heroes/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/heroes/domain/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,18 @@
+package heroes.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberInfoResponse {
+    @Schema(description = "유저 프로필 이미지")
+    private String profileUrl;
+
+    @Schema(description = "유저 닉네임")
+    private String nickname;
+
+    @Schema(description = "유저 이메일")
+    private String email;
+}


### PR DESCRIPTION
## 💡 Issue
- #45 

## 📌 Work Description
### 일반 유저 정보 조회 로직 구현
- 디자인대로 프로필 이미지, 닉네임, 유저 이메일이 조회되도록 설정했습니다. 

## 📝 Reference
- X

## 📚 Etc
- X