### PR TITLE
[FIX] 카카오 로그인 기업의 유형에 따라 달라질 수 있도록 수정

### DIFF
--- a/src/main/java/heroes/domain/auth/api/AuthController.java
+++ b/src/main/java/heroes/domain/auth/api/AuthController.java
@@ -1,8 +1,7 @@
 package heroes.domain.auth.api;
 
-import static heroes.global.common.constants.SecurityConstants.REDIRECT_LOGIN_CODE;
-
 import heroes.domain.auth.application.AuthService;
+import heroes.domain.auth.dto.request.AuthCodeLoginRequest;
 import heroes.domain.auth.dto.request.TokenRefreshRequest;
 import heroes.domain.auth.dto.response.TokenPairResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,18 +17,10 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthService authService;
 
-    @Operation(summary = "일반 유저 회원가입 및 로그인", description = "일반 유저의 회원가입 및 로그인을 진행합니다.")
-    @GetMapping("/login/normal")
-    public TokenPairResponse normalMemberOauthLogin(
-            @RequestParam(REDIRECT_LOGIN_CODE) String code) {
-        return authService.socialNormalLogin(code);
-    }
-
-    @Operation(summary = "기업 유저 회원가입 및 로그인", description = "기업 유저의 회원가입 및 로그인을 진행합니다.")
-    @GetMapping("/login/company")
-    public TokenPairResponse companyMemberOauthLogin(
-            @RequestParam(REDIRECT_LOGIN_CODE) String code) {
-        return authService.socialCompanyLogin(code);
+    @Operation(summary = "회원가입 및 로그인", description = "회원가입 및 로그인을 진행합니다.")
+    @PostMapping("/login")
+    public TokenPairResponse memberOauthLogin(@RequestBody AuthCodeLoginRequest request) {
+        return authService.socialLogin(request);
     }
 
     @Operation(summary = "토큰 재발급", description = "엑세스 토큰 및 리프테시 토큰을 모두 재발급합니다.")

--- a/src/main/java/heroes/domain/auth/application/AuthService.java
+++ b/src/main/java/heroes/domain/auth/application/AuthService.java
@@ -6,6 +6,7 @@ import static heroes.domain.member.domain.MemberRole.USER;
 import heroes.domain.auth.dao.RefreshTokenRepository;
 import heroes.domain.auth.dto.AccessTokenDto;
 import heroes.domain.auth.dto.RefreshTokenDto;
+import heroes.domain.auth.dto.request.AuthCodeLoginRequest;
 import heroes.domain.auth.dto.request.TokenRefreshRequest;
 import heroes.domain.auth.dto.response.KakaoTokenLoginResponse;
 import heroes.domain.auth.dto.response.TokenPairResponse;
@@ -13,7 +14,6 @@ import heroes.domain.company.dao.CompanyRepository;
 import heroes.domain.company.domain.Company;
 import heroes.domain.member.dao.MemberRepository;
 import heroes.domain.member.domain.Member;
-import heroes.domain.member.domain.MemberRole;
 import heroes.domain.member.domain.OauthInfo;
 import heroes.global.error.exception.CustomException;
 import heroes.global.error.exception.ErrorCode;
@@ -37,22 +37,12 @@ public class AuthService {
     private final MemberUtil memberUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public TokenPairResponse socialNormalLogin(String code) {
-        KakaoTokenLoginResponse response = kakaoService.getNormalUserIdToken(code);
+    public TokenPairResponse socialLogin(AuthCodeLoginRequest request) {
+        KakaoTokenLoginResponse response = kakaoService.getIdToken(request.getCode());
         OidcUser oidcUser = idTokenVerifier.getOidcUser(response.getId_token());
         OauthInfo oauthInfo = OauthInfo.from(oidcUser);
 
-        Member member = getMemberByOidcInfo(oidcUser, oauthInfo, USER);
-        jwtTokenService.setAuthenticationToken(member.getId(), member.getRole());
-        return getLoginResponse(member);
-    }
-
-    public TokenPairResponse socialCompanyLogin(String code) {
-        KakaoTokenLoginResponse response = kakaoService.getCompanyUserIdToken(code);
-        OidcUser oidcUser = idTokenVerifier.getOidcUser(response.getId_token());
-        OauthInfo oauthInfo = OauthInfo.from(oidcUser);
-
-        Member member = getMemberByOidcInfo(oidcUser, oauthInfo, COMPANY);
+        Member member = getMemberByOidcInfo(oidcUser, oauthInfo, request.getRole());
         jwtTokenService.setAuthenticationToken(member.getId(), member.getRole());
         return getLoginResponse(member);
     }
@@ -101,7 +91,7 @@ public class AuthService {
         return new TokenPairResponse(accessToken, refreshToken);
     }
 
-    private Member getMemberByOidcInfo(OidcUser oidcUser, OauthInfo oauthInfo, MemberRole role) {
+    private Member getMemberByOidcInfo(OidcUser oidcUser, OauthInfo oauthInfo, String role) {
         return memberRepository
                 .findByOauthInfo(oauthInfo)
                 .orElseGet(() -> saveMember(oauthInfo, getUserSocialName(oidcUser), role));
@@ -111,11 +101,11 @@ public class AuthService {
         return oidcUser.getClaim("nickname");
     }
 
-    private Member saveMember(OauthInfo oauthInfo, String username, MemberRole role) {
-        if (role != null && role.equals(COMPANY)) {
+    private Member saveMember(OauthInfo oauthInfo, String username, String role) {
+        if (role != null && role.equals(COMPANY.toString())) {
             Company company = companyRepository.save(Company.createEmptyCompany());
             return memberRepository.save(Member.createCompanyMember(oauthInfo, username, company));
-        } else if (role != null && role.equals(USER)) {
+        } else if (role != null && role.equals(USER.toString())) {
             return memberRepository.save(Member.createNormalMember(oauthInfo, username));
         }
         throw new CustomException(ErrorCode.NOT_EXISTED_ROLE);

--- a/src/main/java/heroes/domain/auth/application/KakaoService.java
+++ b/src/main/java/heroes/domain/auth/application/KakaoService.java
@@ -5,16 +5,12 @@ import static heroes.global.common.constants.SecurityConstants.KAKAO_WITHDRAWAL_
 
 import heroes.domain.auth.dto.request.KakaoTokenLoginRequest;
 import heroes.domain.auth.dto.response.KakaoTokenLoginResponse;
-import heroes.global.error.exception.CustomException;
-import heroes.global.error.exception.ErrorCode;
 import heroes.infra.config.oauth.KakaoProperties;
 import heroes.infra.feign.KakaoLoginClient;
 import heroes.infra.feign.KakaoWithdrawalClient;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoService {
@@ -22,24 +18,9 @@ public class KakaoService {
     private final KakaoWithdrawalClient kakaoWithdrawalClient;
     private final KakaoProperties properties;
 
-    public KakaoTokenLoginResponse getNormalUserIdToken(String code) {
-        try {
-            return kakaoLoginClient.getToken(
-                    KakaoTokenLoginRequest.newNormalRequest(properties, code).toString());
-        } catch (Exception e) {
-            log.info(e.getMessage());
-            throw new CustomException(ErrorCode.BAD_KAKAO_LOGIN_REQUEST);
-        }
-    }
-
-    public KakaoTokenLoginResponse getCompanyUserIdToken(String code) {
-        try {
-            return kakaoLoginClient.getToken(
-                    KakaoTokenLoginRequest.newCompanyRequest(properties, code).toString());
-        } catch (Exception e) {
-            log.info(e.getMessage());
-            throw new CustomException(ErrorCode.BAD_KAKAO_LOGIN_REQUEST);
-        }
+    public KakaoTokenLoginResponse getIdToken(String code) {
+        return kakaoLoginClient.getToken(
+                KakaoTokenLoginRequest.newInstance(properties, code).toString());
     }
 
     public void withdrawal(Long oauthId) {

--- a/src/main/java/heroes/domain/auth/dto/request/KakaoTokenLoginRequest.java
+++ b/src/main/java/heroes/domain/auth/dto/request/KakaoTokenLoginRequest.java
@@ -18,23 +18,12 @@ public class KakaoTokenLoginRequest {
     private String clientSecret;
     private String grantType;
 
-    public static KakaoTokenLoginRequest newNormalRequest(KakaoProperties properties, String code) {
+    public static KakaoTokenLoginRequest newInstance(KakaoProperties properties, String code) {
         return KakaoTokenLoginRequest.builder()
                 .code(code)
                 .clientId(properties.getId())
                 .clientSecret(properties.getSecret())
-                .redirectUri(properties.getNormalRedirectUri())
-                .grantType(properties.getGrantType())
-                .build();
-    }
-
-    public static KakaoTokenLoginRequest newCompanyRequest(
-            KakaoProperties properties, String code) {
-        return KakaoTokenLoginRequest.builder()
-                .code(code)
-                .clientId(properties.getId())
-                .clientSecret(properties.getSecret())
-                .redirectUri(properties.getCompanyRedirectUri())
+                .redirectUri(properties.getRedirectUri())
                 .grantType(properties.getGrantType())
                 .build();
     }

--- a/src/main/java/heroes/global/common/constants/SecurityConstants.java
+++ b/src/main/java/heroes/global/common/constants/SecurityConstants.java
@@ -6,7 +6,6 @@ public final class SecurityConstants {
 
     public static final String KAKAO_LOGIN_URL = "https://kauth.kakao.com";
     public static final String KAKAO_LOGIN_ENDPOINT = "/oauth/token";
-    public static final String REDIRECT_LOGIN_CODE = "code";
 
     public static final String KAKAO_WITHDRAWAL_URL = "https://kapi.kakao.com";
     public static final String KAKAO_WITHDRAWAL_ENDPOINT = "/v1/user/unlink";

--- a/src/main/java/heroes/global/error/exception/ErrorCode.java
+++ b/src/main/java/heroes/global/error/exception/ErrorCode.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     SAMPLE_ERROR(HttpStatus.BAD_REQUEST, "HS4000", "Sample Error Message"),
     NOT_ALLOWED_SUBLEVEL(HttpStatus.BAD_REQUEST, "HS4001", "아직 업데이트 할 수 없는 양육 단계입니다."),
-    BAD_KAKAO_LOGIN_REQUEST(HttpStatus.BAD_REQUEST, "HS4002", "카카오 로그인 과정에서 오류가 발생했습니다."),
 
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "HS4010", "만료된 JWT 토큰입니다."),
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "HS4011", "ID 토큰 검증에 실패했습니다."),

--- a/src/main/java/heroes/infra/config/oauth/KakaoProperties.java
+++ b/src/main/java/heroes/infra/config/oauth/KakaoProperties.java
@@ -10,8 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class KakaoProperties {
     private String id;
     private String secret;
-    private String normalRedirectUri;
-    private String companyRedirectUri;
+    private String redirectUri;
     private String grantType;
     private String admin;
 }

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -3,8 +3,7 @@ oauth:
     client:
       id: ${KAKAO_CLIENT_ID}
       secret: ${KAKAO_CLIENT_SECRET}
-      normalRedirectUri: ${KAKAO_CLIENT_REDIRECT_URI_NORMAL}
-      companyRedirectUri: ${KAKAO_CLIENT_REDIRECT_URI_COMPANY}
+      redirectUri: ${KAKAO_CLIENT_REDIRECT_URI}
       grantType: ${KAKAO_CLIENT_GRANT_TYPE}
       admin: ${KAKAO_CLIENT_ADMIN}
 jwt:


### PR DESCRIPTION
This reverts commit 19fb6ec608bdf9662aa1551ab427892805b795e5.

## 💡 Issue
- #60 

## 📌 Work Description
- kakao code 요청 프론트엔드에서 담당
- kakao auth/token 백엔드에서 요청
- kakao server -> 백엔드로 결과 전달 
- token 발급 후 redirect url 프론트엔드로 통일
## 📝 Reference
- https://notspoon.tistory.com/36

## 📚 Etc
- 